### PR TITLE
Lyric authorization status

### DIFF
--- a/src/Tekstove/SiteBundle/Model/Lyric/Lyric.php
+++ b/src/Tekstove/SiteBundle/Model/Lyric/Lyric.php
@@ -36,6 +36,12 @@ class Lyric
      * This is prevent us from accidentally displaying the lyric
      */
     private $forbidden = true;
+
+    /**
+     * @var int
+     * By default status is "Not Available"
+     */
+    private $authorizationStatus = 1;
     
     private $sendBy;
     private $sendByUser;
@@ -83,6 +89,7 @@ class Lyric
             'sendBy',
             'download',
             'forbidden',
+            'authorizationStatus',
             
             'videoYoutube',
             'videoVbox7',
@@ -409,7 +416,15 @@ class Lyric
     {
         return $this->popularity;
     }
-    
+
+    /**
+     * @return int
+     */
+    public function getAuthorizationStatus(): int
+    {
+        return $this->authorizationStatus;
+    }
+
     /**
      * @param string $property
      * @return int|null

--- a/src/Tekstove/SiteBundle/Model/Lyric/Lyric.php
+++ b/src/Tekstove/SiteBundle/Model/Lyric/Lyric.php
@@ -14,6 +14,13 @@ use Tekstove\SiteBundle\Model\Language;
 class Lyric
 {
     use \Tekstove\SiteBundle\Helper\ChangeSetable;
+
+    /**
+     * No information available
+     */
+    const AUTHORIZATION_NA = 1;
+    const AUTHORIZATION_ALLOWED = 2;
+    const AUTHORIZATION_ARTIST_FORBIDDEN = 3;
     
     private $id;
     
@@ -41,7 +48,7 @@ class Lyric
      * @var int
      * By default status is "Not Available"
      */
-    private $authorizationStatus = 1;
+    private $authorizationStatus = self::AUTHORIZATION_NA;
     
     private $sendBy;
     private $sendByUser;

--- a/src/Tekstove/SiteBundle/Resources/views/Lyric/view.html.twig
+++ b/src/Tekstove/SiteBundle/Resources/views/Lyric/view.html.twig
@@ -128,7 +128,11 @@
         <div class="col-md-6">
             <div class="panel panel-default">
                 <div class="panel-body">
-                    {% if lyric.isForbidden %}
+                    {% if lyric.authorizationStatus == 2 %}
+                        {{ lyric.text|e|nl2br }}
+                    {% elseif  lyric.authorizationStatus == 3 %}
+                        Имаме забрана за текстовете на изпълнителя!
+                    {% else %}
                         Нямаме права да ви покажем текства :( <br/>
                         Собственици на текса може да са:
                         <ul>
@@ -140,8 +144,6 @@
                         Без разрешение, ние нямаме право да покажем текста! <br/>
                         Ако сте собственик на текста, моля пишете ни на tekstove.info@gmail.com за съгласие.<br/>
                         Съобщение &quot;Съгласен съм текстовете ми да бъдат показвани на сайта&quot; е напълно достатъчно!<br/>
-                    {% else %}
-                        {{ lyric.text|e|nl2br }}
                     {%  endif %}
                 </div>
             </div>

--- a/src/Tekstove/SiteBundle/Resources/views/Lyric/view.html.twig
+++ b/src/Tekstove/SiteBundle/Resources/views/Lyric/view.html.twig
@@ -128,10 +128,10 @@
         <div class="col-md-6">
             <div class="panel panel-default">
                 <div class="panel-body">
-                    {% if lyric.authorizationStatus == 2 %}
+                    {% if lyric.authorizationStatus is constant('Tekstove\\SiteBundle\\Model\\Lyric\\Lyric::AUTHORIZATION_ALLOWED') %}
                         {{ lyric.text|e|nl2br }}
-                    {% elseif  lyric.authorizationStatus == 3 %}
-                        Имаме забрана за текстовете на изпълнителя!
+                    {% elseif  lyric.authorizationStatus is constant('Tekstove\\SiteBundle\\Model\\Lyric\\Lyric::AUTHORIZATION_ARTIST_FORBIDDEN') %}
+                        Имаме забрана от изпълнителя!
                     {% else %}
                         Нямаме права да ви покажем текства :( <br/>
                         Собственици на текса може да са:


### PR DESCRIPTION
There are sites allowing lyric embedding.
We should use these sites when we don't have information if we are allowed to show the lyric.
If artist or lyric is forbidden -> do not show the lyric.
If we don't have auth info -> try 3rd party embedding
if we are allowed to display the lyric -> display the lyric

For now just identify if lyric is forbidden or no information is available