### PR TITLE
Errors from logs

### DIFF
--- a/src/Tekstove/SiteBundle/Controller/ArtistController.php
+++ b/src/Tekstove/SiteBundle/Controller/ArtistController.php
@@ -45,7 +45,7 @@ class ArtistController extends Controller
             $artistV4Data = $artistGatewayV4->get($id);
             $artistV4 = $artistV4Data['item'];
             $artist->setFacebookPageId($artistV4->getFacebookPageId());
-        } catch (\Exception $ex) {
+        } catch (\Exception $e) {
             $this->get('logger')->error('Artist version 4 not found', ['ex' => $e]);
         }
 


### PR DESCRIPTION
Fix the following error

```
[Sat Jan 19 11:43:15.722742 2019] [fcgid:warn] [pid 17119:tid 140141192460032] [client xxxxxxx:20904] mod_fcgid: stderr: Error#8.
Undefined variable: e in /var/www/tekstove-site/build/2019_01_17-23-04-59/src/Tekstove/SiteBundle/Controller/ArtistController.php : 49
```